### PR TITLE
Hack `Foundation.hs` to remove TH parts

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -9,7 +9,6 @@ dependencies:
 
 - yesod 
 - yesod-core 
-- yesod-routes
 - yesod-auth 
 - yesod-static 
 - yesod-form

--- a/package.yaml
+++ b/package.yaml
@@ -9,6 +9,7 @@ dependencies:
 
 - yesod 
 - yesod-core 
+- yesod-routes
 - yesod-auth 
 - yesod-static 
 - yesod-form

--- a/src/Settings/StaticFiles.hs
+++ b/src/Settings/StaticFiles.hs
@@ -4,7 +4,8 @@
 module Settings.StaticFiles where
 
 import Settings     (appStaticDir, compileTimeAppSettings)
-import Yesod.Static (staticFiles)
+import Yesod.Static -- (staticFiles)
+
 -- import qualified Prelude as P
 -- This generates easy references to files in the static directory at compile time,
 -- giving you compile-time verification that referenced files exist.
@@ -18,4 +19,51 @@ import Yesod.Static (staticFiles)
 -- If the identifier is not available, you may use:
 --
 --     StaticFile ["js", "script.js"] []
-staticFiles (appStaticDir compileTimeAppSettings)
+-- staticFiles (appStaticDir compileTimeAppSettings)
+
+css_bootstrap_css :: Yesod.Static.StaticRoute
+css_bootstrap_css = undefined
+{-
+      = (Yesod.Static.StaticRoute
+           ((map Data.Text.pack) ["css", "bootstrap.css"]))
+          [(Data.Text.pack "etag", Data.Text.pack "PDMJ7RwX")]
+-}
+
+fonts_glyphicons_halflings_regular_woff :: Yesod.Static.StaticRoute
+fonts_glyphicons_halflings_regular_woff = undefined
+
+{-
+      = (Yesod.Static.StaticRoute
+           ((map Data.Text.pack)
+              ["fonts", "glyphicons-halflings-regular.woff"]))
+          [(Data.Text.pack "etag", Data.Text.pack "aO0drAa_")]
+-}
+
+fonts_glyphicons_halflings_regular_eot :: Yesod.Static.StaticRoute
+fonts_glyphicons_halflings_regular_eot = undefined
+
+{-
+      = (Yesod.Static.StaticRoute
+           ((map Data.Text.pack)
+              ["fonts", "glyphicons-halflings-regular.eot"]))
+          [(Data.Text.pack "etag", Data.Text.pack "etF8YIXe")]
+-}
+
+fonts_glyphicons_halflings_regular_ttf :: Yesod.Static.StaticRoute
+fonts_glyphicons_halflings_regular_ttf = undefined
+
+{-
+      = (Yesod.Static.StaticRoute
+           ((map Data.Text.pack)
+              ["fonts", "glyphicons-halflings-regular.ttf"]))
+          [(Data.Text.pack "etag", Data.Text.pack "5J1S50t2")]
+-}
+
+fonts_glyphicons_halflings_regular_svg :: Yesod.Static.StaticRoute
+fonts_glyphicons_halflings_regular_svg = undefined
+{-
+      = (Yesod.Static.StaticRoute
+           ((map Data.Text.pack)
+              ["fonts", "glyphicons-halflings-regular.svg"]))
+           [(Data.Text.pack "etag", Data.Text.pack "MpQdYzAE")]<Paste>
+-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,7 +37,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps: [] 
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Looks like TH is interacting badly with the GHC API, e.g. this bug report is 10 years old (and closed) but seems to have the same error message

https://gitlab.haskell.org/ghc/ghc/issues/2739

It could be that the fix involves passing some flags into GHC while compiling from LH, I will try to fiddle with that tomorrow (any chance you know @gridaphobe?)

At any rate, here's a hack to get to the actually important part of the work -- any TH parts have just been replaced with `undefined` -- if we can't actually fix the LH-GHC-API-TH problem at the least we can add
a `cabal` flag and 

* use `undefined` when _checking_ the code with LH, but 
* use the actual TH generated code when _executing_ (by switching the flag "off") 

Details on how that works are here

https://guide.aelve.com/haskell/cpp-vww0qd72#item-oh9ytz0p

If you merge this PR in, then LH complains (legitimately) about various parse 
errors in `src/DBApi.hs` that you should then work on fixing to make progress.